### PR TITLE
Add Dalink sponsorship link to GitHub FUNDING custom list

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://boosty.to/0xffff']
+custom: ['https://dalink.to/b4tman1', 'https://boosty.to/0xffff']


### PR DESCRIPTION
### Motivation
- Add `https://dalink.to/b4tman1` as a custom sponsorship option and make it primary so it appears first in GitHub's funding UI.

### Description
- Updated `.github/FUNDING.yml` to `custom: ['https://dalink.to/b4tman1', 'https://boosty.to/0xffff']` and committed the change with the message `[skip ci] Add Dalink sponsor link to GitHub funding custom list`.

### Testing
- Ran `git status --short`, `cat .github/FUNDING.yml`, `git show --stat --oneline`, and `nl -ba .github/FUNDING.yml` to verify the file content and commit; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e091ff40832e91437f04cd8145af)